### PR TITLE
libcameraservice: Add support to set vendor tag with client package name

### DIFF
--- a/media/libmediaplayerservice/StagefrightRecorder.cpp
+++ b/media/libmediaplayerservice/StagefrightRecorder.cpp
@@ -1114,6 +1114,8 @@ status_t StagefrightRecorder::setParameter(
         }
     } else if (key == "log-session-id") {
         return setLogSessionId(value);
+    } else if (key == "set-title") {
+        return OK;
     } else {
         ALOGE("setParameter: failed to find key %s", key.c_str());
     }

--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -125,6 +125,8 @@ cc_library {
 
     defaults: [
         "libcameraservice_deps",
+        "uses_oplus_camera_defaults",
+        "uses_nothing_camera_defaults",
     ],
     // Camera service source
 

--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -126,7 +126,6 @@ cc_library {
     defaults: [
         "libcameraservice_deps",
         "uses_oplus_camera_defaults",
-        "uses_nothing_camera_defaults",
     ],
     // Camera service source
 

--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -171,6 +171,9 @@ constexpr int32_t kInvalidDeviceId = -1;
 // Set to keep track of logged service error events.
 static std::set<std::string> sServiceErrorEventSet;
 
+// Current camera package name
+static std::string sCurrPackageName;
+
 CameraService::CameraService(
         std::shared_ptr<CameraServiceProxyWrapper> cameraServiceProxyWrapper,
         std::shared_ptr<AttributionAndPermissionUtils> attributionAndPermissionUtils) :
@@ -1467,6 +1470,10 @@ Status CameraService::filterGetInfoErrorCode(status_t err) {
     }
 }
 
+std::string CameraService::getCurrPackageName() {
+    return sCurrPackageName;
+}
+
 Status CameraService::makeClient(const sp<CameraService>& cameraService,
         const sp<IInterface>& cameraCb, const std::string& packageName, bool systemNativeClient,
         const std::optional<std::string>& featureId,  const std::string& cameraId,
@@ -2442,6 +2449,8 @@ Status CameraService::connectHelper(const sp<CALLBACK>& cameraCb, const std::str
     ALOGI("CameraService::connect call (PID %d \"%s\", camera ID %s) and "
             "Camera API version %d", packagePid, clientPackageName.c_str(), cameraId.c_str(),
             static_cast<int>(effectiveApiLevel));
+
+    sCurrPackageName = clientPackageName;
 
     nsecs_t openTimeNs = systemTime();
 

--- a/services/camera/libcameraservice/CameraService.h
+++ b/services/camera/libcameraservice/CameraService.h
@@ -324,6 +324,8 @@ public:
     // Shared utilities
     static binder::Status filterGetInfoErrorCode(status_t err);
 
+    static std::string getCurrPackageName();
+
     /**
      * Returns true if the device is an automotive device and cameraId is system
      * only camera which has characteristic AUTOMOTIVE_LOCATION value as either

--- a/services/camera/libcameraservice/device3/Camera3Device.cpp
+++ b/services/camera/libcameraservice/device3/Camera3Device.cpp
@@ -25,6 +25,13 @@
 #define ALOGVV(...) ((void)0)
 #endif
 
+#ifdef USES_OPLUS_CAMERA
+#define TAG_NAME "com.oplus.packageName"
+#endif
+#ifdef USES_NOTHING_CAMERA
+#define TAG_NAME "com.nothing.device.package_name"
+#endif
+
 // Convenience macro for transient errors
 #define CLOGE(fmt, ...) ALOGE("Camera %s: %s: " fmt, mId.c_str(), __FUNCTION__, \
             ##__VA_ARGS__)
@@ -2397,6 +2404,27 @@ status_t Camera3Device::configureStreamsLocked(int operatingMode,
         CLOGE("Invalid operating mode: %d", operatingMode);
         return BAD_VALUE;
     }
+
+#ifdef TAG_NAME
+    sp<VendorTagDescriptor> vTags;
+    sp<VendorTagDescriptorCache> vCache = VendorTagDescriptorCache::getGlobalVendorTagCache();
+    if (vCache.get()) {
+        const camera_metadata_t *metaBuffer = sessionParams.getAndLock();
+        metadata_vendor_id_t vendorId = get_camera_metadata_vendor_id(metaBuffer);
+        sessionParams.unlock(metaBuffer);
+        vCache->getVendorTagDescriptor(vendorId, &vTags);
+        uint32_t tag;
+        if (CameraMetadata::getTagFromName(TAG_NAME, vTags.get(), &tag)) {
+            ALOGE("%s: Unable to get %s tag", __FUNCTION__, TAG_NAME);
+        } else {
+            std::string pkgName = CameraService::getCurrPackageName();
+            status_t res = const_cast<CameraMetadata&>(sessionParams).update(tag, String8(pkgName.c_str()));
+            if (res) {
+                ALOGE("%s: metadata update failed, res = %d", __FUNCTION__, res);
+            }
+        }
+    }
+#endif
 
     bool isConstrainedHighSpeed =
             CAMERA_STREAM_CONFIGURATION_CONSTRAINED_HIGH_SPEED_MODE == operatingMode;

--- a/services/camera/libcameraservice/device3/Camera3Device.cpp
+++ b/services/camera/libcameraservice/device3/Camera3Device.cpp
@@ -28,9 +28,6 @@
 #ifdef USES_OPLUS_CAMERA
 #define TAG_NAME "com.oplus.packageName"
 #endif
-#ifdef USES_NOTHING_CAMERA
-#define TAG_NAME "com.nothing.device.package_name"
-#endif
 
 // Convenience macro for transient errors
 #define CLOGE(fmt, ...) ALOGE("Camera %s: %s: " fmt, mId.c_str(), __FUNCTION__, \


### PR DESCRIPTION
* OEMs like OnePlus and Nothing detect camera package name to unlock features like 48mp.